### PR TITLE
fix deadlock caused by writing multiple values to simulink provider

### DIFF
--- a/src/bennu/executables/bennu-simulink-provider/main.cpp
+++ b/src/bennu/executables/bennu-simulink-provider/main.cpp
@@ -228,6 +228,7 @@ public:
     {
         std::string result;
 
+        sem_wait(mUpdatesSemaphore);
         for (auto &it : tags)
         {
             std::string tag{it.first};
@@ -236,7 +237,6 @@ public:
             // recieve write and format newDto
             if (mDebug) { std::cout << "BennuSimulinkProvider::write ---- received write for tag: " << tag << " -- " << value << std::endl; }
             std::scoped_lock<std::shared_mutex> lock(mLock);
-            sem_wait(mUpdatesSemaphore);
             std::string dataStr, dataType;
             if(value == "true" || value == "false")
             {
@@ -268,13 +268,13 @@ public:
                 break;
             }
         }
+        sem_post(mUpdatesSemaphore);
 
         if (result.empty())
         {
             result += "ACK=Updated tags in Simulink provider";
         }
 
-        sem_post(mUpdatesSemaphore);
         return result;
     }
 


### PR DESCRIPTION
Currently, the write loop in `bennu-simulink-provider` will decrement `mUpdatesSemaphore` by one in each iteration, while the semaphore is only incremented once before the function returns. This works fine for writing single values, but if the loop iterates more than once, it will deadlock on `mUpdatesSemaphore`. The patch ensures there is no net change in `mUpdatesSemaphore` per loop iteration.