### PR TITLE
Fix versioning for realsies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .vscode
 .idea
 
+bennu.deb
+pybennu.deb
 build
 *.autosave
 #*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,16 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# unix timestamp
+string(TIMESTAMP BUILD_TIMESTAMP "%s")
+
 # CMake requires semantic versions with integer components
 # Set it to something static so stuff works
-set(bennu_VERSION "6.0.0")
+# Example: 6.0.1707507861
+set(bennu_VERSION "6.0.${BUILD_TIMESTAMP}")
 
 # Add commit hash to the version for use by the Deb package builder
-# Example: 6.0.0.f7055755
+# Example: 6.0.1707507861.94edd945
 set(bennu_VERSION_WITH_COMMIT "${bennu_VERSION}.${bennu_SHORT_HASH}")
 
 project(bennu

--- a/build_bennu_deb.sh
+++ b/build_bennu_deb.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex
+
+mkdir -p ./build
+cd ./build
+cmake ../
+make -j "$(nproc)"
+sudo make package
+cp ./*.deb ../bennu.deb
+cd ../

--- a/cmake/CpackConfig.cmake
+++ b/cmake/CpackConfig.cmake
@@ -17,7 +17,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Sandia National Laboratories <emulytics@san
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libasio-dev, libboost-date-time-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev")
 set(CPACK_DEBIAN_PACKAGE_SECTION misc)
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION ${CMAKE_PROJECT_DESCRIPTION})
-set(CPACK_PACKAGE_FILE_NAME "bennu-${CPACK_DEBIAN_PACKAGE_VERSION}_amd64_${timestamp}")
+set(CPACK_PACKAGE_FILE_NAME "bennu-${CPACK_DEBIAN_PACKAGE_VERSION}_amd64")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${CMAKE_PROJECT_HOMEPAGE_URL})
 
 include(CPack)

--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -36,13 +36,13 @@ POST = $(CURDIR)/postinst
 define PACKAGE_DESCRIPTION
 Modeling and simulation application for SCADA/ICS.
 endef
-TIMESTAMP = $(shell date +%Y%m%d_%H-%M-%S)
 PACKAGE_SECTION = python
 PACKAGE_PRIORITY = extra
 PACKAGE_COMPRESSION = bzip2
-PACKAGE_FULL_VERSION := 6.0.0.$(shell git rev-parse --short HEAD)
+# 6.0.1707507794.8a88a442
+PACKAGE_FULL_VERSION := 6.0.$(shell date +%s).$(shell git rev-parse --short HEAD)
 PACKAGE_NAME = pybennu
-PACKAGE_FILENAME = $(PACKAGE_NAME)_$(PACKAGE_FULL_VERSION)_amd64_$(TIMESTAMP).deb
+PACKAGE_FILENAME = $(PACKAGE_NAME)_$(PACKAGE_FULL_VERSION)_amd64.deb
 PACKAGE_VENDOR = SNL
 PACKAGE_MAINTAINER = Sandia National Laboratories <emulytics@sandia.gov>
 PACKAGE_LICENSE = GPLv3

--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -107,7 +107,7 @@ clean-pyc:
 	@find . -name ".cache" -exec rm -rfv {} +
 
 deb: packagetools
-	@mkdir -p dist/
+	@mkdir -p $(DIST_DIR)
 	@$(FPM) \
 		--verbose \
 		-f \

--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -27,7 +27,7 @@ endif
 
 BUILD_DIR = $(CURDIR)/build
 DIST_DIR = $(CURDIR)/dist
-POST = $(CURDIR)/dist/postinst
+POST = $(CURDIR)/postinst
 
 ##
 # Packaging
@@ -108,22 +108,6 @@ clean-pyc:
 
 deb: packagetools
 	@mkdir -p dist/
-	@echo 'printf "\n--- RUNNING PYBENNU AFTER INSTALL SCRIPT ---\n\n"' > $(POST)
-	@echo 'mv /root/libzmq* /usr/lib/x86_64-linux-gnu' >> $(POST)
-	@echo 'printf "\n\tINSTALLING ZMQ WITH DRAFT SUPPORT...\n\n"' >> $(POST)
-	@echo 'wget --no-check-certificate https://raw.githubusercontent.com/zeromq/pyzmq/main/examples/draft/install.sh' >> $(POST)
-	@echo 'sed -i -e "s/wget/wget --no-check-certificate/g" install.sh' >> $(POST)
-	@echo 'sed -i -e "s/pip install/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -I/g" install.sh' >> $(POST)
-	@echo 'chmod +x install.sh' >> $(POST)
-	@echo './install.sh' >> $(POST)
-	@echo 'printf "\n\tINSTALLING HELICS/PYHELICS...\n\n"' >> $(POST)
-	@echo 'wget --no-check-certificate -O pyhelics.tgz https://github.com/GMLC-TDC/pyhelics/releases/download/v2.7.1/helics-2.7.1.tar.gz' >> $(POST)
-	@echo 'mkdir -p /tmp/pyhelics && tar -C /tmp/pyhelics -xzf pyhelics.tgz && rm pyhelics.tgz' >> $(POST)
-	@echo 'cd /tmp/pyhelics/helics-2.7.1 && sed -i "s/helics-apps/helics-apps~=2.7.1/" /tmp/pyhelics/helics-2.7.1/setup.py' >> $(POST)
-	@echo 'pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org /tmp/pyhelics/helics-2.7.1/' >> $(POST)
-	@echo 'printf "\n\tINSTALLING PYBENNU PIP DEPENDENCIES...\n\n"' >> $(POST)
-	@echo 'pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org bitarray elasticsearch>=5.3.0 helics~=2.7.1 matplotlib>=1.5.3 networkx>=1.11 numpy>=1.11.2 opendssdirect.py~=0.6.1 py-expression-eval~=0.3.14 PYPOWER>=5.0.1 pyserial>=3.4 pyyaml>=3.12 requests>=2.20 scipy>=0.18.1 sysv_ipc' >> $(POST)
-	@echo 'printf "\nDONE!!\n\n"' >> $(POST)
 	@$(FPM) \
 		--verbose \
 		-f \

--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -37,7 +37,7 @@ define PACKAGE_DESCRIPTION
 Modeling and simulation application for SCADA/ICS.
 endef
 PACKAGE_SECTION = python
-PACKAGE_PRIORITY = extra
+PACKAGE_PRIORITY = optional
 PACKAGE_COMPRESSION = bzip2
 # 6.0.1707507794.8a88a442
 PACKAGE_FULL_VERSION := 6.0.$(shell date +%s).$(shell git rev-parse --short HEAD)
@@ -46,7 +46,7 @@ PACKAGE_FILENAME = $(PACKAGE_NAME)_$(PACKAGE_FULL_VERSION)_amd64.deb
 PACKAGE_VENDOR = SNL
 PACKAGE_MAINTAINER = Sandia National Laboratories <emulytics@sandia.gov>
 PACKAGE_LICENSE = GPLv3
-PACKAGE_URL = https://github.com/sandialabs/sceptre-bennu.git
+PACKAGE_URL = https://github.com/sandialabs/sceptre-bennu
 PACKAGE_ARCHITECTURE = amd64
 
 ##

--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -63,7 +63,7 @@ endef
 ##
 # Targets
 ##
-.PHONY: dist test docs
+.PHONY: packagetools pytools root clean clean-build clean-pyc deb dist sdist install install-dev uninstall wheelhouse bull
 
 help:
 	@echo "clean		- Remove python and build file artifacts."
@@ -113,7 +113,6 @@ deb: packagetools
 	@echo 'printf "\n\tINSTALLING ZMQ WITH DRAFT SUPPORT...\n\n"' >> $(POST)
 	@echo 'wget --no-check-certificate https://raw.githubusercontent.com/zeromq/pyzmq/main/examples/draft/install.sh' >> $(POST)
 	@echo 'sed -i -e "s/wget/wget --no-check-certificate/g" install.sh' >> $(POST)
-	@echo 'sed -i -e "s/make -j/make -j $(nproc)/g" install.sh' >> $(POST)
 	@echo 'sed -i -e "s/pip install/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -I/g" install.sh' >> $(POST)
 	@echo 'chmod +x install.sh' >> $(POST)
 	@echo './install.sh' >> $(POST)

--- a/src/pybennu/postinst
+++ b/src/pybennu/postinst
@@ -1,0 +1,26 @@
+set -ex
+
+printf "\n--- RUNNING PYBENNU AFTER INSTALL SCRIPT ---\n\n"
+mv /root/libzmq* /usr/lib/x86_64-linux-gnu
+
+printf "\n\tINSTALLING ZMQ WITH DRAFT SUPPORT...\n\n"
+wget --no-check-certificate https://raw.githubusercontent.com/zeromq/pyzmq/main/examples/draft/install.sh
+sed -i -e "s/wget/wget --no-check-certificate/g" install.sh
+sed -i -e "s/pip install/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -I/g" install.sh
+chmod +x install.sh
+./install.sh
+rm ./install.sh
+
+printf "\n\tINSTALLING HELICS/PYHELICS...\n\n"
+wget --no-check-certificate -O pyhelics.tgz https://github.com/GMLC-TDC/pyhelics/releases/download/v2.7.1/helics-2.7.1.tar.gz
+mkdir -p /tmp/pyhelics
+tar -C /tmp/pyhelics -xzf pyhelics.tgz
+rm pyhelics.tgz
+cd /tmp/pyhelics/helics-2.7.1
+sed -i "s/helics-apps/helics-apps~=2.7.1/" /tmp/pyhelics/helics-2.7.1/setup.py
+pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org /tmp/pyhelics/helics-2.7.1/
+
+printf "\n\tINSTALLING PYBENNU PIP DEPENDENCIES...\n\n"
+pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org bitarray 'elasticsearch>=5.3.0' 'helics~=2.7.1' 'matplotlib>=1.5.3' 'networkx>=1.11' 'numpy>=1.11.2' 'opendssdirect.py~=0.6.1' 'py-expression-eval~=0.3.14' 'PYPOWER>=5.0.1' 'pyserial>=3.4' 'pyyaml>=3.12' 'requests>=2.20' 'scipy>=0.18.1' sysv_ipc
+
+printf "\nDONE!!\n\n"

--- a/src/pybennu/postinst
+++ b/src/pybennu/postinst
@@ -14,7 +14,7 @@ fi
 printf "\n\tINSTALLING ZMQ WITH DRAFT SUPPORT...\n\n"
 wget --no-check-certificate https://raw.githubusercontent.com/zeromq/pyzmq/main/examples/draft/install.sh
 sed -i -e "s/wget/wget --no-check-certificate/g" install.sh
-sed -i -e "s/pip install/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -I/g" install.sh
+sed -i -e "s/pip install/pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -I/g" install.sh
 chmod +x install.sh
 ./install.sh
 rm ./install.sh

--- a/src/pybennu/postinst
+++ b/src/pybennu/postinst
@@ -1,8 +1,16 @@
 set -ex
 
 printf "\n--- RUNNING PYBENNU AFTER INSTALL SCRIPT ---\n\n"
-mv /root/libzmq* /usr/lib/x86_64-linux-gnu
+if [[ ! -f /usr/lib/x86_64-linux-gnu/libzmq.a ]]; then
+    mv /root/libzmq.a /usr/lib/x86_64-linux-gnu/
+fi
+if [[ ! -f /usr/lib/x86_64-linux-gnu/libzmq.so.5.1.5 ]]; then
+    mv /root/libzmq.so.5.1.5 /usr/lib/x86_64-linux-gnu/
+fi
+# mv /root/libzmq* /usr/lib/x86_64-linux-gnu
 
+# TODO: we should statically include our own version of install.sh
+# instead of downloading it every build and running sed on it
 printf "\n\tINSTALLING ZMQ WITH DRAFT SUPPORT...\n\n"
 wget --no-check-certificate https://raw.githubusercontent.com/zeromq/pyzmq/main/examples/draft/install.sh
 sed -i -e "s/wget/wget --no-check-certificate/g" install.sh

--- a/src/pybennu/setup.py
+++ b/src/pybennu/setup.py
@@ -155,7 +155,7 @@ setup(
     # https://github.com/pypa/setuptools_scm
     version                 = '6.0.0',
     description             = 'bennu python providers and utilities',
-    url                     = 'https://github.com/sandialabs/sceptre-bennu.git',
+    url                     = 'https://github.com/sandialabs/sceptre-bennu',
     author                  = 'Sandia National Laboratories',
     author_email            = 'emulytics@sandia.gov',
     license                 = 'GPLv3',


### PR DESCRIPTION
- Add Unix timestamp to version to ensure packages get ordered by time, since apt will install the latest after sorting alphabetically.
- Fix zmq install in pybennu. Yeah, it was using `pip` instead of `pip3`, so this might have been broken for a while and no one noticed. I added `set -e` to the install script to ensure it exits if any of the commands fail in the future
- Move postinstall into a separate script, instead of inline in the Makefile
- Add a script to build C++ bennu
- Some minor cleanup