### PR TITLE
IEC-104 server and client updates

### DIFF
--- a/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.cpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.cpp
@@ -229,7 +229,7 @@ bool ClientConnection::asduReceivedHandler(void* parameter, int address, CS101_A
             }
             else
             {
-                printf("IOA: %i- Double point value is in indetrminate state..defaulting to 0\n", addr);
+                printf("IOA: %i- Double point value is in indeterminate state..defaulting to 0\n", addr);
                 status = 0;
             }
             printf("    IOA: %i value: %i\n", addr, status);

--- a/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.cpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.cpp
@@ -60,6 +60,14 @@ void ClientConnection::start(std::shared_ptr<ClientConnection> clientConnection)
     }
 }
 
+int ClientConnection::convertBoolToDPValue(bool value)
+{
+    if (value == 0)
+        return IEC60870_DOUBLE_POINT_OFF;
+    else
+        return IEC60870_DOUBLE_POINT_ON;
+}
+
 StatusMessage ClientConnection::readRegisterByTag(const std::string& tag, comms::RegisterDescriptor& rd)
 {
     auto status = getRegisterDescriptorByTag(tag, rd) ? STATUS_SUCCESS : STATUS_FAIL;
@@ -73,7 +81,7 @@ StatusMessage ClientConnection::readRegisterByTag(const std::string& tag, comms:
     return sm;
 }
 
-StatusMessage ClientConnection::writeBinary(const std::string& tag, bool value)
+StatusMessage ClientConnection::writeBinary(const std::string& tag, bool bvalue)
 {
     StatusMessage sm = STATUS_INIT;
     comms::RegisterDescriptor rd;
@@ -86,15 +94,18 @@ StatusMessage ClientConnection::writeBinary(const std::string& tag, bool value)
         return sm;
     }
 
-    // Write boolean using protocol
-    std::cout << "Send single command C_SC_NA_1: " << tag << " -- " << value << std::endl;
-    InformationObject sc = (InformationObject)
-            SingleCommand_create(NULL, rd.mRegisterAddress, value, true, 0);
-    CS104_Connection_sendProcessCommandEx(mConnection, CS101_COT_ACTIVATION, 1, sc);
-    InformationObject_destroy(sc);
+    // Convert boolean to double point value
+    int value = ClientConnection::convertBoolToDPValue(bvalue);
 
-    // Update local data so we don't have to wait until the next poll
-    updateBinary(rd.mRegisterAddress, value);
+    // Write double point using protocol
+    std::cout << "Send double command C_DC_NA_1: " << tag << " -- " << bvalue << std::endl;
+    InformationObject dc = (InformationObject)
+            DoubleCommand_create(NULL, rd.mRegisterAddress, value, true, 0);
+    CS104_Connection_sendProcessCommandEx(mConnection, CS101_COT_ACTIVATION, 1, dc);
+    InformationObject_destroy(dc);
+
+    // Update local data so we don't have to wait until the next poll; save boolean to datastore
+    updateBinary(rd.mRegisterAddress, bvalue);
     return sm;
 }
 
@@ -194,28 +205,44 @@ bool ClientConnection::asduReceivedHandler(void* parameter, int address, CS101_A
         }
     }
     // Binary values
-    else if (CS101_ASDU_getTypeID(asdu) == M_SP_NA_1) {
-        printf("  single point information:\n");
+    else if (CS101_ASDU_getTypeID(asdu) == M_DP_NA_1) {
+        printf("  double point information:\n");
 
         int i;
 
         for (i = 0; i < CS101_ASDU_getNumberOfElements(asdu); i++) {
 
-            SinglePointInformation io =
-                    (SinglePointInformation) CS101_ASDU_getElement(asdu, i);
+            DoublePointInformation io =
+                    (DoublePointInformation) CS101_ASDU_getElement(asdu, i);
 
             uint16_t addr = InformationObject_getObjectAddress((InformationObject) io);
-            bool status = SinglePointInformation_getValue((SinglePointInformation) io);
+            DoublePointValue dp_value = DoublePointInformation_getValue((DoublePointInformation) io);
+
+            bool status = 0;
+            if (dp_value == IEC60870_DOUBLE_POINT_OFF)
+            {
+                status = 0;
+            }
+            else if (dp_value == IEC60870_DOUBLE_POINT_ON)
+            {
+                status = 1;
+            }
+            else
+            {
+                printf("IOA: %i- Double point value is in indetrminate state..defaulting to 0\n", addr);
+                status = 0;
+            }
             printf("    IOA: %i value: %i\n", addr, status);
 
             gClientConnection->updateBinary(addr, status);
 
-            SinglePointInformation_destroy(io);
+            DoublePointInformation_destroy(io);
         }
     }
 
     return true;
 }
+
 
 } // namespace iec60870
 } // namespace comms

--- a/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.hpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/ClientConnection.hpp
@@ -9,6 +9,7 @@
 
 #include "bennu/devices/modules/comms/base/Common.hpp"
 #include "bennu/devices/modules/comms/iec60870-5/protocol/src/inc/api/cs104_connection.h"
+#include "bennu/devices/modules/comms/iec60870-5/protocol/src/inc/api/cs101_information_objects.h"
 
 
 namespace bennu {
@@ -74,6 +75,8 @@ public:
     static void connectionHandler(void* parameter, CS104_Connection connection, CS104_ConnectionEvent event);
     static bool asduReceivedHandler(void* parameter, int address, CS101_ASDU asdu);
 
+    static int convertBoolToDPValue(bool value);
+
 private:
     bool mRunning;
     std::string mRtuEndpoint;                   // IP/Port or DevName of remote RTU
@@ -81,6 +84,7 @@ private:
     std::map<std::uint16_t, std::string> mBinaryAddressToTagMapping;
     std::map<std::uint16_t, std::string> mAnalogAddressToTagMapping;
     std::map<std::string, comms::RegisterDescriptor> mRegisters;
+    
 
 };
 

--- a/src/bennu/devices/modules/comms/iec60870-5/module/DataHandler.cpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/DataHandler.cpp
@@ -53,6 +53,7 @@ void DataHandler::parseServerTree(std::shared_ptr<Server> server, const ptree& t
         std::string endpoint = tree.get<std::string>("endpoint");
         std::string log = tree.get<std::string>("event-logging", "iec60870-5-104-server.log");
         server->configureEventLogging(log);
+        std::string subtype = tree.get<std::string>("subtype");
         auto binaryInputs = tree.equal_range("binary-input");
         for (auto iter = binaryInputs.first; iter != binaryInputs.second; ++iter)
         {
@@ -88,7 +89,7 @@ void DataHandler::parseServerTree(std::shared_ptr<Server> server, const ptree& t
         // Initialize and start 104 server
         //   - Pass server pointer to Server::start() so Server::gServer can be set statically
         //     and used inside static 104 handlers
-        server->start(endpoint, server, rPollRate);
+        server->start(endpoint, server, rPollRate, subtype);
     }
     catch (ptree_bad_path& e)
     {

--- a/src/bennu/devices/modules/comms/iec60870-5/module/Server.cpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/Server.cpp
@@ -113,16 +113,12 @@ DoublePointValue Server::convertIntToDPValue(int value)
     {
         case 0:
             return IEC60870_DOUBLE_POINT_INTERMEDIATE;
-            break;
         case 1:
             return IEC60870_DOUBLE_POINT_OFF;
-            break;
         case 2:
             return IEC60870_DOUBLE_POINT_ON;
-            break;
         case 3:
             return IEC60870_DOUBLE_POINT_INDETERMINATE;
-            break;
         default:
             return IEC60870_DOUBLE_POINT_INTERMEDIATE;
     }
@@ -162,29 +158,20 @@ void Server::reversePollSinglePoint()
             for (const auto &kv : gServer->mBinaryPoints)
             {
                 const std::string tag = kv.second.first;
-                if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-                {
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto status = gServer->mDataManager->getDataByTag<bool>(tag);
-                        InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
-                }
-                else
+                if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
                 {
                     // Send current ASDU and create a new one for the remaining values
                     IMasterConnection_sendASDU(mConnection, newAsdu);
                     CS101_ASDU_destroy(newAsdu);
                     newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_PERIODIC, 0, 1, false, false);
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto status = gServer->mDataManager->getDataByTag<bool>(tag);
-                        InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
+                }
+
+                if (gServer->mDataManager->hasTag(tag))
+                {
+                    auto status = gServer->mDataManager->getDataByTag<bool>(tag);
+                    InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
+                    CS101_ASDU_addInformationObject(newAsdu, io);
+                    InformationObject_destroy(io);
                 }
             }
             IMasterConnection_sendASDU(mConnection, newAsdu);
@@ -196,29 +183,20 @@ void Server::reversePollSinglePoint()
             for (const auto &kv : gServer->mAnalogPoints)
             {
                 const std::string tag = kv.second.first;
-                if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-                {
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                        InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
-                }
-                else
+                if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
                 {
                     // Send current ASDU and create a new one for the remaining values
                     IMasterConnection_sendASDU(mConnection, newAsdu);
                     CS101_ASDU_destroy(newAsdu);
                     newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_PERIODIC, 0, 1, false, false);
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                        InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
+                }
+
+                if (gServer->mDataManager->hasTag(tag))
+                {
+                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
+                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
+                    CS101_ASDU_addInformationObject(newAsdu, io);
+                    InformationObject_destroy(io);
                 }
             }
             IMasterConnection_sendASDU(mConnection, newAsdu);
@@ -259,29 +237,20 @@ void Server::reversePollDoublePoint()
             for (const auto &kv : gServer->mAnalogPoints)
             {
                 const std::string tag = kv.second.first;
-                if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-                {
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                        InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
-                }
-                else
+                if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
                 {
                     // Send current ASDU and create a new one for the remaining values
                     IMasterConnection_sendASDU(mConnection, newAsdu);
                     CS101_ASDU_destroy(newAsdu);
                     newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_PERIODIC, 0, 1, false, false);
-                    if (gServer->mDataManager->hasTag(tag))
-                    {
-                        auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                        InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                        CS101_ASDU_addInformationObject(newAsdu, io);
-                        InformationObject_destroy(io);
-                    }
+                }
+
+                if (gServer->mDataManager->hasTag(tag))
+                {
+                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
+                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
+                    CS101_ASDU_addInformationObject(newAsdu, io);
+                    InformationObject_destroy(io);
                 }
             }
             IMasterConnection_sendASDU(mConnection, newAsdu);
@@ -320,7 +289,7 @@ void Server::rawMessageHandler(void *parameter, IMasterConnection con, uint8_t *
 */
 bool Server::interrogationHandlerSinglePoint(void *parameter, IMasterConnection connection, CS101_ASDU asdu, uint8_t qoi)
 {
-    printf("Received interrogation for group %i\n", qoi);
+    std::cout << "Received interrogation for group " << static_cast<int16_t>(qoi) << std::endl;
 
     if (qoi == 20) /* only handle station interrogation */
     {
@@ -333,29 +302,20 @@ bool Server::interrogationHandlerSinglePoint(void *parameter, IMasterConnection 
         for (const auto &kv : gServer->mBinaryPoints)
         {
             const std::string tag = kv.second.first;
-            if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-            {
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto status = gServer->mDataManager->getDataByTag<bool>(tag);
-                    InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
-            }
-            else
+            if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
             {
                 // Send current ASDU and create a new one for the remaining values
                 IMasterConnection_sendASDU(connection, newAsdu);
                 CS101_ASDU_destroy(newAsdu);
                 newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_INTERROGATED_BY_STATION, 0, 1, false, false);
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto status = gServer->mDataManager->getDataByTag<bool>(tag);
-                    InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
+            }
+
+            if (gServer->mDataManager->hasTag(tag))
+            {
+                auto status = gServer->mDataManager->getDataByTag<bool>(tag);
+                InformationObject io = (InformationObject)SinglePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
+                CS101_ASDU_addInformationObject(newAsdu, io);
+                InformationObject_destroy(io);
             }
         }
         IMasterConnection_sendASDU(connection, newAsdu);
@@ -367,29 +327,20 @@ bool Server::interrogationHandlerSinglePoint(void *parameter, IMasterConnection 
         for (const auto &kv : gServer->mAnalogPoints)
         {
             const std::string tag = kv.second.first;
-            if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-            {
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
-            }
-            else
+            if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
             {
                 // Send current ASDU and create a new one for the remaining values
                 IMasterConnection_sendASDU(connection, newAsdu);
                 CS101_ASDU_destroy(newAsdu);
                 newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_INTERROGATED_BY_STATION, 0, 1, false, false);
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
+            }
+
+            if (gServer->mDataManager->hasTag(tag))
+            {
+                auto val = gServer->mDataManager->getDataByTag<double>(tag);
+                InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
+                CS101_ASDU_addInformationObject(newAsdu, io);
+                InformationObject_destroy(io);
             }
         }
         IMasterConnection_sendASDU(connection, newAsdu);
@@ -409,7 +360,7 @@ bool Server::interrogationHandlerSinglePoint(void *parameter, IMasterConnection 
 */
 bool Server::interrogationHandlerDoublePoint(void *parameter, IMasterConnection connection, CS101_ASDU asdu, uint8_t qoi)
 {
-    printf("Received interrogation for group %i\n", qoi);
+    std::cout << "Received interrogation for group " << static_cast<int16_t>(qoi) << std::endl;
 
     if (qoi == 20) /* only handle station interrogation */
     {
@@ -422,29 +373,20 @@ bool Server::interrogationHandlerDoublePoint(void *parameter, IMasterConnection 
         for (const auto &kv : gServer->mBinaryPoints)
         {
             const std::string tag = kv.second.first;
-            if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-            {
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto status = Server::convertBoolToDPValue(gServer->mDataManager->getDataByTag<bool>(tag));
-                    InformationObject io = (InformationObject)DoublePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
-            }
-            else
+            if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
             {
                 // Send current ASDU and create a new one for the remaining values
                 IMasterConnection_sendASDU(connection, newAsdu);
                 CS101_ASDU_destroy(newAsdu);
                 newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_INTERROGATED_BY_STATION, 0, 1, false, false);
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto status = Server::convertBoolToDPValue(gServer->mDataManager->getDataByTag<bool>(tag));
-                    InformationObject io = (InformationObject)DoublePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
+            }
+
+            if (gServer->mDataManager->hasTag(tag))
+            {
+                auto status = Server::convertBoolToDPValue(gServer->mDataManager->getDataByTag<bool>(tag));
+                InformationObject io = (InformationObject)DoublePointInformation_create(NULL, kv.first, status, IEC60870_QUALITY_GOOD);
+                CS101_ASDU_addInformationObject(newAsdu, io);
+                InformationObject_destroy(io);
             }
         }
         IMasterConnection_sendASDU(connection, newAsdu);
@@ -456,29 +398,20 @@ bool Server::interrogationHandlerDoublePoint(void *parameter, IMasterConnection 
         for (const auto &kv : gServer->mAnalogPoints)
         {
             const std::string tag = kv.second.first;
-            if (CS101_ASDU_getPayloadSize(newAsdu) < MAX_ASDU_PAYLOAD_SIZE)
-            {
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
-            }
-            else
+            if (CS101_ASDU_getPayloadSize(newAsdu) >= MAX_ASDU_PAYLOAD_SIZE)
             {
                 // Send current ASDU and create a new one for the remaining values
                 IMasterConnection_sendASDU(connection, newAsdu);
                 CS101_ASDU_destroy(newAsdu);
                 newAsdu = CS101_ASDU_create(alParams, false, CS101_COT_INTERROGATED_BY_STATION, 0, 1, false, false);
-                if (gServer->mDataManager->hasTag(tag))
-                {
-                    auto val = gServer->mDataManager->getDataByTag<double>(tag);
-                    InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
-                    CS101_ASDU_addInformationObject(newAsdu, io);
-                    InformationObject_destroy(io);
-                }
+            }
+
+            if (gServer->mDataManager->hasTag(tag))
+            {
+                auto val = gServer->mDataManager->getDataByTag<double>(tag);
+                InformationObject io = (InformationObject)MeasuredValueShort_create(NULL, kv.first, val, IEC60870_QUALITY_GOOD);
+                CS101_ASDU_addInformationObject(newAsdu, io);
+                InformationObject_destroy(io);
             }
         }
         IMasterConnection_sendASDU(connection, newAsdu);
@@ -497,7 +430,7 @@ bool Server::asduHandler(void *parameter, IMasterConnection connection, CS101_AS
 {
     if (CS101_ASDU_getTypeID(asdu) == C_SC_NA_1)
     {
-        printf("received single command\n");
+        std::cout << "received single command" << std::endl;
 
         if (CS101_ASDU_getCOT(asdu) == CS101_COT_ACTIVATION)
         {
@@ -515,8 +448,8 @@ bool Server::asduHandler(void *parameter, IMasterConnection connection, CS101_AS
             }
             else
             {
-                printf("ERROR: message has no valid information object\n");
-                return true;
+                std::cout << "ERROR: message has no valid information object" << std::endl;
+                return false;
             }
         }
         else
@@ -528,7 +461,7 @@ bool Server::asduHandler(void *parameter, IMasterConnection connection, CS101_AS
     }
     else if (CS101_ASDU_getTypeID(asdu) == C_DC_NA_1)
     {
-        printf("received double command\n");
+        std::cout << "received double command" << std::endl;
 
         if (CS101_ASDU_getCOT(asdu) == CS101_COT_ACTIVATION)
         {
@@ -550,12 +483,14 @@ bool Server::asduHandler(void *parameter, IMasterConnection connection, CS101_AS
             }
             else
             {
-                printf("ERROR: message has no valid information object\n");
-                return true;
+                std::cout << "ERROR: message has no valid information object" << std::endl;
+                return false;
             }
         }
         else
+        {
             CS101_ASDU_setCOT(asdu, CS101_COT_UNKNOWN_COT);
+        }
 
         IMasterConnection_sendASDU(connection, asdu);
 

--- a/src/bennu/devices/modules/comms/iec60870-5/module/Server.hpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/Server.hpp
@@ -9,6 +9,8 @@
 #include "bennu/devices/field-device/DataManager.hpp"
 #include "bennu/devices/modules/comms/base/CommsModule.hpp"
 #include "bennu/devices/modules/comms/iec60870-5/protocol/src/inc/api/cs104_slave.h"
+#include "bennu/devices/modules/comms/iec60870-5/protocol/src/inc/api/cs101_information_objects.h"
+#include "bennu/devices/modules/comms/iec60870-5/protocol/src/hal/inc/hal_time.h"
 #include "bennu/utility/DirectLoggable.hpp"
 
 namespace bennu {
@@ -51,7 +53,7 @@ public:
 
     bool addAnalogOutput(const uint16_t address, const std::string& tag);
 
-    void writeBinary(uint16_t address, bool value);
+    void writeBinary(uint16_t address, int value);
 
     void writeAnalog(uint16_t address, float value);
 
@@ -62,6 +64,10 @@ public:
     static bool connectionRequestHandler(void* parameter, const char* ipAddress);
     static void connectionEventHandler(void* parameter, IMasterConnection con, CS104_PeerConnectionEvent event);
 
+    static DoublePointValue convertBoolToDPValue(bool status);
+    static DoublePointValue convertIntToDPValue(int status);
+    static void sendSpontaneousUpdate(IMasterConnection connection, int ioa, DoublePointValue value);
+
 private:
     bool mConnected;
     uint32_t mReversePollRate;                              // Server reverse-poll rate
@@ -69,6 +75,7 @@ private:
     std::shared_ptr<std::thread> pServerPollThread;			// Server reverse-poll thread
     std::map<uint16_t, std::pair<std::string, PointType>> mBinaryPoints;
     std::map<uint16_t, std::pair<std::string, PointType>> mAnalogPoints;
+
 
 };
 

--- a/src/bennu/devices/modules/comms/iec60870-5/module/Server.hpp
+++ b/src/bennu/devices/modules/comms/iec60870-5/module/Server.hpp
@@ -41,9 +41,11 @@ class Server : public CommsModule, public utility::DirectLoggable, public std::e
 public:
     Server(std::shared_ptr<field_device::DataManager> dm);
 
-    void start(const std::string& endpoint, std::shared_ptr<Server> server, const uint32_t rPollRate);
+    void start(const std::string& endpoint, std::shared_ptr<Server> server, const uint32_t rPollRate, std::string subtype);
 
-    void reversePoll();
+    void reversePollSinglePoint();
+
+    void reversePollDoublePoint();
 
     bool addBinaryInput(const uint16_t address, const std::string& tag);
 
@@ -53,13 +55,16 @@ public:
 
     bool addAnalogOutput(const uint16_t address, const std::string& tag);
 
+    void writeBinary(uint16_t address, bool value);
+
     void writeBinary(uint16_t address, int value);
 
     void writeAnalog(uint16_t address, float value);
 
     // IEC60870-5-104 message callback handlers
     static void rawMessageHandler(void* parameter, IMasterConnection con, uint8_t* msg, int msgSize, bool sent);
-    static bool interrogationHandler(void* parameter, IMasterConnection connection, CS101_ASDU asdu, uint8_t qoi);
+    static bool interrogationHandlerSinglePoint(void* parameter, IMasterConnection connection, CS101_ASDU asdu, uint8_t qoi);
+    static bool interrogationHandlerDoublePoint(void* parameter, IMasterConnection connection, CS101_ASDU asdu, uint8_t qoi);
     static bool asduHandler(void* parameter, IMasterConnection connection, CS101_ASDU asdu);
     static bool connectionRequestHandler(void* parameter, const char* ipAddress);
     static void connectionEventHandler(void* parameter, IMasterConnection con, CS104_PeerConnectionEvent event);


### PR DESCRIPTION
Updates to IEC-104 server and client to support double point binary values. Bennu datastore still uses booleans for binary points, so we have to convert back and forth to make this work