### PR TITLE
Fix CI and improve Docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,12 +5,11 @@ on:
     branches: [ "main", "**" ]
 
 jobs:
-
   build:
-
+    name: Build Docker image
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag sceptre-bennu:$(date +%s)
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Build the Docker image
+        run: docker build --pull --file Dockerfile --tag sceptre-bennu:$(date +%s) .

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -13,18 +13,18 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
-      # 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,17 +32,16 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,10 @@ RUN cmake -j$(nproc) -D BUILD_GOBENNU=OFF ../ \
   && make -j$(nproc) install \
   && rm -rf /tmp/*
 
+# Gem install failures: https://github.com/jordansissel/fpm/issues/2048
+# For now, manually install dotenv 2.8.1
 RUN gem install dotenv -v 2.8.1 && gem install fpm -v 1.15.1
+
 RUN python3 -m pip install --no-cache-dir --upgrade aptly-ctl pip setuptools twine wheel
 
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,8 @@ WORKDIR /tmp/bennu/build
 RUN cmake -D BUILD_GOBENNU=OFF ../ && make -j$(nproc) install \
   && rm -rf /tmp/*
 
-RUN gem install fpm
-RUN pip3 install --trusted-host pypy.org --trusted-host files.pythonhosted.org -U aptly-ctl pip setuptools twine wheel
+RUN gem install dotenv -v 2.8.1 && gem install fpm -v 1.15.1
+RUN python3 -m pip install --no-cache-dir --upgrade aptly-ctl pip setuptools twine wheel
 
 WORKDIR /root
 CMD /bin/bash


### PR DESCRIPTION
This is working locally and CI. All good to merge.

## Changes
- Fix docker build
- CMake build in parallel. This substantially speeds up build if system has multiple cores, e.g. when building locally.
- Enable customization of base image and pip index
- Disable caching of pip packages
- Better apt cleanup
- Remove `--trusted-host` args from pip installs (unsafe and not needed)