### PR TITLE
add libzmq5-dev to pybennu dependencies

### DIFF
--- a/src/pybennu/Makefile
+++ b/src/pybennu/Makefile
@@ -122,6 +122,7 @@ deb: packagetools
 		-d python3-setuptools \
 		-d wget \
 		-d libboost-python-dev \
+		-d libzmq5-dev \
 		-p '$(subst __colon__,:,$(DIST_DIR)/$(PACKAGE_FILENAME))' \
 		--name '$(PACKAGE_NAME)' \
 		$(call iter,$(PACKAGE_VENDOR),--vendor) \


### PR DESCRIPTION
It's required for the build that is part of the post-install script

Fixes #26 