### PR TITLE
pybennu: lock pypower version to 5.1.16

### DIFF
--- a/src/pybennu/setup.py
+++ b/src/pybennu/setup.py
@@ -102,7 +102,7 @@ requires = [
     'numpy>=1.11.2',  # >=1.11.2  ~=1.21.2
     'opendssdirect.py~=0.6.1',
     'py-expression-eval~=0.3.14',
-    'PYPOWER>=5.1.16',  # ==5.1.15
+    'PYPOWER==5.1.16',  # ==5.1.15
     'pyserial>=3.4',  # >=3.4
     'PyYAML>=3.12',  # pyyaml>=3.12  ==5.4.1
     'requests>=2.20',  # ~=2.26.0


### PR DESCRIPTION
5.1.17 causes breaking changes with pybennu. This was released in September 2024

With 5.1.17 there is a missing dependency, and even when that's fixed the soap model immediately goes unsolvable on startup. pypower is listed as unmaintained, so recommend locking to the latest known good version 5.1.16