### PR TITLE
Pybennu modbus fixes

### DIFF
--- a/src/pybennu/postinst
+++ b/src/pybennu/postinst
@@ -91,6 +91,6 @@ $PIPINSTALL --no-cache-dir --force-reinstall --no-binary helics 'helics==3.6.1'
 # These are dependencies that aren't apt packages or the version required is newer than is available in apt
 # For example, pybennu requires pymodbus >=3.6.0, but ubuntu 22.04 apt has pymodbus 2.1.0
 printf "\n\tINSTALLING PYBENNU PIP DEPENDENCIES...\n\n"
-$PIPINSTALL --ignore-installed 'elasticsearch<9.0.0' 'opendssdirect.py~=0.6.1' 'py-expression-eval==0.3.14' 'PYPOWER==5.1.16' 'labjack-ljm~=1.23.0' 'pymodbus>=3.6.0,<4.0.0' 'pydantic>2.0.0,<3.0.0' 'pydantic-settings'
+$PIPINSTALL --ignore-installed 'elasticsearch<9.0.0' 'opendssdirect.py~=0.6.1' 'py-expression-eval==0.3.14' 'PYPOWER==5.1.16' 'labjack-ljm~=1.23.0' 'pymodbus>=3.8.0,<=3.9.2' 'pydantic>2.0.0,<3.0.0' 'pydantic-settings'
 
 printf "\nDONE!!\n\n"

--- a/src/pybennu/pybennu/elastic.py
+++ b/src/pybennu/pybennu/elastic.py
@@ -143,6 +143,7 @@ ES_BASE_TYPE_MAPPING = {
             "tag": {"type": "keyword"},
             "type": {"type": "keyword"},
             "value": {"type": "keyword"},  # TODO: how do we make value properly typed?
+            "description": {"type": "keyword"},
         }
     },
     "sceptre": {

--- a/src/pybennu/pybennu/elastic.py
+++ b/src/pybennu/pybennu/elastic.py
@@ -140,10 +140,17 @@ ES_BASE_TYPE_MAPPING = {
     },
     "groundtruth": {
         "properties": {
+            "description": {"type": "keyword"},
             "tag": {"type": "keyword"},
             "type": {"type": "keyword"},
-            "value": {"type": "keyword"},  # TODO: how do we make value properly typed?
-            "description": {"type": "keyword"},
+            # Kibana doesn't allow dynamic typing without using runtime fields
+            # This is a minor hack to store the value as both keyword type in .value,
+            # and as it's actual type in a separate field, e.g. "float" field will have
+            # the value for floating point values.
+            "value": {"type": "keyword"},
+            "float": {"type": "double"},
+            "bool": {"type": "boolean"},
+            "int": {"type": "integer"},
         }
     },
     "sceptre": {

--- a/src/pybennu/pybennu/executables/pybennu_probe.py
+++ b/src/pybennu/pybennu/executables/pybennu_probe.py
@@ -10,7 +10,7 @@ import pybennu.distributed.client as client
 import pybennu.distributed.swig._Endpoint as E
 
 
-def handler(reply):
+def handler(reply: str) -> None:
     split = reply.split(',')
     print("Reply:")
     if len(split) > 1:
@@ -20,42 +20,50 @@ def handler(reply):
         print("\t", split[0])
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-e', '--endpoint',
         default='tcp://127.0.0.1:1330',
-        help="FEP (:1330) or Provider (:5555) endpoint"
+        help="FEP (:1330) or Provider (:5555) endpoint, e.g. 'tcp://172.16.1.2:5555' or 'tcp://127.0.0.1:1330'"
     )
     parser.add_argument(
         '-c', '--command',
         default='query',
         choices=['query', 'read', 'write', 'raw'],
-        help="Command to issue query|read|write|raw"
+        help="Command to issue: query | read | write | raw"
     )
     parser.add_argument(
         '-t', '--tag',
-        help="Full tag name, e.g. bus101.active"
+        help="Full tag name, e.g. 'bus101.active', 'br1.closed' or 'pv_power.value'"
     )
     value_group = parser.add_mutually_exclusive_group()
     value_group.add_argument(
         '-v', '--value',
-        help='Value (for analog)'
-    )
-    value_group.add_argument(
-        '-r', '--raw', type=str,
-        help='Raw command to issue, passed as-is. '
-             'Example: "WRITE=G1CB1_binary_input_closed:1,G2CB2_binary_input_closed:1,G3CB3_binary_input_closed:1"'
+        help='Value to write (for analog tags)'
     )
     value_group.add_argument(
         '-s', '--status',
         choices=['true', 'false', '1', '0'],
-        help='Status (for bool)'
+        help="Status (for boolean tags), one of: true | 1 | false | 0"
     )
+    value_group.add_argument(
+        '-r', '--raw', type=str,
+        help='Raw command to issue, passed as-is. '
+             'Example: --raw "WRITE=G1CB1_binary_input_closed:1,G2CB2_binary_input_closed:1,G3CB3_binary_input_closed:1"'
+    )
+
     args = parser.parse_args()
 
     endpoint = E.new_Endpoint()
     E.Endpoint_str_set(endpoint, args.endpoint)
+
+    # print(E.Endpoint_str_get(endpoint))
+    # tcp://172.16.1.2:5555
+
+    # print(E.Endpoint_hash(endpoint))
+    # 15fd2f305feef8d
+
     probe = client.Client(endpoint)
     probe.reply_handler = handler
 

--- a/src/pybennu/pybennu/modbus.py
+++ b/src/pybennu/pybennu/modbus.py
@@ -27,7 +27,7 @@ class ModbusWrapper:
         )
 
         # DEBUG level for pymodbus outputs for EVERY request, only use
-        # if you're debugging a really hairy modbus issue.
+        # if you're debugging a really hairy Modbus issue.
         # Otherwise, we set WARNING+ normally, and INFO+ if debug is set.
         # This must be called because logging basicConfig() in the provider
         # will result in the pymodbus logger also getting configured, and
@@ -37,7 +37,7 @@ class ModbusWrapper:
         else:
             pymodbus_apply_logging_config(logging.WARNING)
 
-        # Close modbus connection on exit.
+        # Close Modbus connection on exit.
         # register the "at exit" handler here instead of
         # on connection so it only gets registered once
         # for a given client. Calling close() if connection
@@ -168,10 +168,10 @@ class ModbusWrapper:
         # TODO: other types of registers
         # TODO: what exception is raised by PyModbus if response is an error?
         if r.reg_type == 'holding':  # Holding Registers
-            encoded_value = self.encode_float(value)
+            encoded_value = self.encode_float(float(value))
             self.client.write_registers(r.num, encoded_value)
         elif r.reg_type == 'coil':  # Coil
-            self.client.write_coil(r.num, value)
+            self.client.write_coil(r.num, bool(value))
         elif r.reg_type in ['discrete', 'input']:
             raise NotImplementedError(f"reg_type {r.reg_type} is not supported for writing for register {r.name}")
         else:

--- a/src/pybennu/pybennu/modbus.py
+++ b/src/pybennu/pybennu/modbus.py
@@ -7,6 +7,7 @@ from pymodbus.exceptions import ModbusException
 from pymodbus import pymodbus_apply_logging_config
 
 from pybennu.settings import ModbusRegister
+from pybennu import utils
 
 
 class ModbusWrapper:
@@ -171,6 +172,9 @@ class ModbusWrapper:
             encoded_value = self.encode_float(float(value))
             self.client.write_registers(r.num, encoded_value)
         elif r.reg_type == 'coil':  # Coil
+            # The ZMQ messages are strings "true" or "false"
+            if isinstance(value, str):
+                value = utils.str_to_bool(value)
             self.client.write_coil(r.num, bool(value))
         elif r.reg_type in ['discrete', 'input']:
             raise NotImplementedError(f"reg_type {r.reg_type} is not supported for writing for register {r.name}")

--- a/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
+++ b/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
@@ -301,6 +301,7 @@ class OPALRT(Provider):
                             "tag": tag,
                             "type": reg.data_type,
                             "value": value,
+                            "description": reg.description,
                         },
                     }
                     es_bodies.append(es_body)

--- a/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
+++ b/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
@@ -229,6 +229,7 @@ class OPALRT(Provider):
                 if self.conf.modbus.retry_attempts and retry_count < self.conf.modbus.retry_attempts:
                     self.log.error(f"Sleeping for {self.conf.modbus.retry_delay} seconds before retrying read...")
                     time.sleep(self.conf.modbus.retry_delay)
+                    retry_count += 1
                     continue
                 elif self.conf.modbus.retry_attempts:
                     # Wait to rebuild Modbus connection in a loop
@@ -252,6 +253,7 @@ class OPALRT(Provider):
                 )
 
             # Wait before re-polling
+            retry_count = 0
             time.sleep(self.conf.modbus.polling_rate)
 
     def _modbus_data_writer(self) -> None:

--- a/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
+++ b/src/pybennu/pybennu/providers/power/solvers/opal_rt.py
@@ -315,9 +315,12 @@ class OPALRT(Provider):
                     # This is a minor hack to store the value as both keyword type in .value,
                     # and as it's actual type in a separate field, e.g. "float" field will have
                     # the value for floating point values.
-                    if isinstance(value, float):
-                        es_body["groundtruth"]["float"] = value
-                    elif isinstance(value, bool):
+                    if isinstance(value, (bool, float, int)):
+                        es_body["groundtruth"]["float"] = float(value)
+                    else:
+                        self.log.warning(f"Unknown data type '{type(value)}' for tag '{tag}' (description: {reg.description})")
+
+                    if isinstance(value, bool):
                         es_body["groundtruth"]["bool"] = value
                     elif isinstance(value, int):
                         es_body["groundtruth"]["int"] = value

--- a/src/pybennu/setup.py
+++ b/src/pybennu/setup.py
@@ -118,7 +118,7 @@ requires = [
     'labjack-ljm~=1.23.0',
     # NOTE: need at least pymodbus 3+. The version in apt
     # for ubuntu 22.04 is 2.1.0, which is too old.
-    # NOTE: pymodbus 3.7.0 dropped support for Python 3.8
+    # NOTE: pymodbus 3.9.0 informally dropped support for Python 3.9
     'pymodbus>=3.8.0,<=3.9.2',
     'pydantic>2.0.0,<3.0.0',
     # NOTE: pydantic-settings 2.9.0 dropped support for Python 3.8
@@ -177,12 +177,11 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Microsoft :: Windows :: Windows 7',
-        'Programming Language :: Python :: 3.8',   # Ubuntu 20 (focal)
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',  # Ubuntu 22 (jammy)
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    python_requires         = '>=3.8,<4.0',
+    python_requires         = '>=3.9,<4.0',
     entry_points            = entries,
     data_files              = data_files,
     packages                = find_packages(),

--- a/src/pybennu/setup.py
+++ b/src/pybennu/setup.py
@@ -119,7 +119,7 @@ requires = [
     # NOTE: need at least pymodbus 3+. The version in apt
     # for ubuntu 22.04 is 2.1.0, which is too old.
     # NOTE: pymodbus 3.7.0 dropped support for Python 3.8
-    'pymodbus>=3.6.0,<4.0.0',
+    'pymodbus>=3.8.0,<=3.9.2',
     'pydantic>2.0.0,<3.0.0',
     # NOTE: pydantic-settings 2.9.0 dropped support for Python 3.8
     'pydantic-settings',


### PR DESCRIPTION
# Pybennu Modbus fixes

## Description
- Multiple fixes to pybennu's Modbus functionality, notably for the OPALRT provider. It's working pretty well for reads and writes now.
- Add more fields to "groundtruth" in Kibana, notably "typed" values for float, int, and bool. This makes it easier to create dashboards, because Kibana can't interpret a keyword-type field (aka a string) as an arbitrary type, you'd have to manually do so via a runtime field or processor on the Elasticsearch side (more dev work). This is a far simpler solution that is trivial to implement on provider side.
- bump minimum python version for Pybennu to 3.9
- bump min version of pymodbus to 3.8 and max to 3.9.2

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-bennu/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
